### PR TITLE
fix: offAll now triggers only with undefined or null

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -5,7 +5,7 @@ type Entry<E, K extends keyof E> = {
   value: E[K];
 };
 
-const isNil = (value: unknown): value is null | undefined =>
+const isNullish = (value: unknown): value is null | undefined =>
   value === null || value === undefined;
 
 export class EventEmitter<E extends Record<string, unknown[]>> {
@@ -124,7 +124,7 @@ export class EventEmitter<E extends Record<string, unknown[]>> {
     eventName?: K,
     listener?: (...args: E[K]) => void,
   ): Promise<this> {
-    if (!isNil(eventName)) {
+    if (!isNullish(eventName)) {
       if (listener) {
         this.#listeners[eventName] = this.#listeners[eventName]?.filter(
           ({ cb }) => cb !== listener,

--- a/mod.ts
+++ b/mod.ts
@@ -5,6 +5,9 @@ type Entry<E, K extends keyof E> = {
   value: E[K];
 };
 
+const isNil = (value: unknown): value is null | undefined =>
+  value === null || value === undefined;
+
 export class EventEmitter<E extends Record<string, unknown[]>> {
   #listeners: {
     [K in keyof E]?: Array<{
@@ -43,7 +46,8 @@ export class EventEmitter<E extends Record<string, unknown[]>> {
         this.#listeners[eventName] = [];
       }
       if (
-        this.#limit !== 0 && this.#listeners[eventName]!.length >= this.#limit
+        this.#limit !== 0 &&
+        this.#listeners[eventName]!.length >= this.#limit
       ) {
         throw new TypeError("Listeners limit reached: limit is " + this.#limit);
       }
@@ -57,7 +61,8 @@ export class EventEmitter<E extends Record<string, unknown[]>> {
         this.#onWriters[eventName] = [];
       }
       if (
-        this.#limit !== 0 && this.#onWriters[eventName]!.length >= this.#limit
+        this.#limit !== 0 &&
+        this.#onWriters[eventName]!.length >= this.#limit
       ) {
         throw new TypeError("Listeners limit reached: limit is " + this.#limit);
       }
@@ -87,7 +92,8 @@ export class EventEmitter<E extends Record<string, unknown[]>> {
       this.#listeners[eventName] = [];
     }
     if (
-      this.#limit !== 0 && this.#listeners[eventName]!.length >= this.#limit
+      this.#limit !== 0 &&
+      this.#listeners[eventName]!.length >= this.#limit
     ) {
       throw new TypeError("Listeners limit reached: limit is " + this.#limit);
     }
@@ -118,7 +124,7 @@ export class EventEmitter<E extends Record<string, unknown[]>> {
     eventName?: K,
     listener?: (...args: E[K]) => void,
   ): Promise<this> {
-    if (eventName) {
+    if (!isNil(eventName)) {
       if (listener) {
         this.#listeners[eventName] = this.#listeners[eventName]?.filter(
           ({ cb }) => cb !== listener,

--- a/test.ts
+++ b/test.ts
@@ -171,7 +171,7 @@ Deno.test("closeMixed", async () => {
     }
   })();
 
-  for await (const x of ee) {
+  for await (const _x of ee) {
     await ee.off();
   }
 });


### PR DESCRIPTION
Hello and thank you for such a fantastic library.

I was using this library and encountered weird behaviour - after the `.once` event listener run, all listeners disappeared. I was using the `number`'s as event names for the event map, and one event had the name `0`. 0 is a falsy value, so it triggers `offAll` behaviour when is passed into the `off` function.

I've added the additional utility function `isNil`, which detects if the received value is `null` or `undefined` and doesn't break with other falsy values, like an empty string, etc.